### PR TITLE
fix : refresh error

### DIFF
--- a/plan-today/src/components/MainBox.js
+++ b/plan-today/src/components/MainBox.js
@@ -8,7 +8,6 @@ function MainBox(){
     const [show, setShow] = useState(0);
     const [todos, setTodos] = useState(()=>{
         const savedTodos = localStorage.getItem("todos");
-
         if(savedTodos){
             return JSON.parse(savedTodos);
         }
@@ -53,7 +52,7 @@ function MainBox(){
     }
 
     const handleDelete = (e) => {
-        setTodos(todos.filter(current => `${current.id}` !== `${e.target.id}`));
+        setTodos(todos.filter(todo => `${todo.id}` !== `${e.target.id}`));
     }
 
     return(

--- a/plan-today/src/components/Todo.js
+++ b/plan-today/src/components/Todo.js
@@ -3,20 +3,26 @@ import styles from "../css/Todo.module.css";
 
 function Todo({todo, handleDelete, id, todos, setTodos, checked, show}){
     const [mod, setMod] = useState(true);
-    const [newInput, setNewInput] = useState("");
+    const [newInput, setNewInput] = useState(todo);
     const [newSubmit, setNewSubmit] = useState(todo);
     const [check, setCheck] = useState(checked);
     const [hide, setHide] = useState(false);
+    const [refresh, setRefresh] = useState(false);
 
     useEffect(()=>{
-        let copyArray = Array.from(todos);
-        copyArray[id - 1] = {id : id, todo : newSubmit, checked : check};
-        setTodos(copyArray);
+        if(refresh){
+            let copyArray = Array.from(todos);
+            copyArray[id - 1] = {id : id, todo : newSubmit, checked : check};
+            setTodos(copyArray);
+        }
+    },[newSubmit, check]);
+
+    useEffect(()=>{
         if(show === 0) setHide(false);
         else if(show === -1 & check === false) setHide(false);
         else if(show === 1 & check === true) setHide(false);
         else setHide(true);
-    },[newSubmit, check, show]);
+    },[check, show])
 
     const modify = () =>{
         setMod(current => !current);
@@ -29,14 +35,17 @@ function Todo({todo, handleDelete, id, todos, setTodos, checked, show}){
     const onSubmit = (e) => {
         e.preventDefault();
         setNewSubmit(newInput);
+        setRefresh(true);
         modify();
     }
 
     const handleChecked = (e) => {
         if(e.target.checked === true){
+            setRefresh(true);
             setCheck(true);
         }
         else{
+            setRefresh(true);
             setCheck(false);
         }
     }


### PR DESCRIPTION
창을 새로고침 했을 때 todos 배열에 원하지 않는 값이 저장되는 오류를 발견하고 이를 수정하였다.
Todo.js 에서 todo를 고치거나 checkBox에 변화가 있을 때 이를 반영하기 위해 만든 useEffect에서 새로고침이 발생할 때 newSubmit과 check state에 변화가 생겨 원치 않는 값이 입력되어 오류가 발생한 것이었다. 이를 해결하기 위해 refresh state를 초기값 false로 선언하고, Todo.js에서 submit과 check 이벤트가 발생할 때 이를 true로 변경하여 refresh가 true일 때만 해당 값들로 todos를 수정할 수 있게 변경하였다.